### PR TITLE
Validate Table, Column, and Alias strings.

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -12,6 +12,9 @@ class Column implements Sql, Field
 
     public function __construct(string $name, ?TableReference $table = null, ?string $alias = null)
     {
+        assert(preg_match('#^([0-9a-zA-Z$_]+|\*)$#', $name) === 1);
+        assert($alias === null || preg_match('#^[0-9a-zA-Z$_]+$#', $alias) === 1);
+
         $this->name = $name;
         $this->table = $table;
         $this->alias = $alias;

--- a/src/Table.php
+++ b/src/Table.php
@@ -10,6 +10,9 @@ class Table implements Sql, TableReference
 
     public function __construct(string $table, ?string $alias = null)
     {
+        assert(preg_match('#^[0-9a-zA-Z$_]+$#', $table) === 1);
+        assert($alias === null || preg_match('#^[0-9a-zA-Z$_]+$#', $alias) === 1);
+
         $this->table = $table;
         $this->alias = $alias;
     }


### PR DESCRIPTION
Verify only valid unquoted identifier characters are passed into the Table and Column properties. While these should never be directly user input this should prevent accidental user input from causing additional SQL injection.

https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
> Permitted characters in unquoted identifiers:
> - ASCII: [0-9,a-z,A-Z$_] (basic Latin letters, digits 0-9, dollar, underscore)
> - Extended: U+0080 .. U+FFFF

We are not attempting to quote identifiers so we should only have to check against the unquoted identifier list.

`$table('*')` is a special case that should only occur in the SELECT field list, but is allowed without context.